### PR TITLE
Update broadcast serializer to include creator email

### DIFF
--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -2,6 +2,7 @@ from django.db.models import Count
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.broadcast import Broadcast, BroadcastSeen
+from sentry.users.models.user import User
 
 
 @register(Broadcast)
@@ -44,13 +45,21 @@ class AdminBroadcastSerializer(BroadcastSerializer):
             .annotate(user_count=Count("broadcast"))
             .values_list("broadcast", "user_count")
         )
+        created_by_ids = {item.created_by_id for item in item_list if item.created_by_id}
+        users = {
+            user.id: user.email
+            for user in User.objects.filter(id__in=created_by_ids)
+        }
 
-        for item in attrs:
-            attrs[item]["user_count"] = counts.get(item.id, 0)
+        for item in item_list:
+            attrs.setdefault(item, {})["user_count"] = counts.get(item.id, 0)
+            if item.created_by_id:
+                attrs[item]["created_by"] = users.get(item.created_by_id)
+
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs):
         context = super().serialize(obj, attrs, user)
         context["userCount"] = attrs["user_count"]
-        context["createdBy"] = obj.created_by_id.id if obj.created_by_id else None
+        context["createdBy"] = attrs.get("created_by")
         return context


### PR DESCRIPTION
This PR updates the `AdminBroadcastSerializer` to include the creator's email address in the `createdBy` field instead of their ID. This provides more informative broadcast serialization.

The `get_attrs` method was modified to efficiently fetch user emails for all broadcasts in a single query, and the `serialize` method now uses this pre-fetched email.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-72ef7b82-1372-4831-95f6-8656a6ef9d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72ef7b82-1372-4831-95f6-8656a6ef9d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

